### PR TITLE
Fix jinja2 templating warning.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,11 +14,11 @@
 
 - name: set git username
   shell: git config --global user.name "{{git_user_name}}"
-  when: git_user_email_result.stdout != "{{git_user_name}}"
+  when: git_user_email_result.stdout != "git_user_name|string"
 
 - name: set git user email
   shell: git config --global user.email "{{git_user_email}}"
-  when: git_user_email_result.stdout != "{{git_user_email}}"
+  when: git_user_email_result.stdout != "git_user_email|string"
 
 - name: install homebrew via the curl oneliner
   shell: ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"


### PR DESCRIPTION
Fix for the following warnings.
```
TASK [roderik.superlumic-homebrew : set git username] ****************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}.
Found: git_user_email_result.stdout != "{{git_user_name}}"

changed: [localhost]

TASK [roderik.superlumic-homebrew : set git user email] **************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}.
Found: git_user_email_result.stdout != "{{git_user_email}}"

skipping: [localhost]
```