### PR TITLE
[Fixes #3] This was causing CI to fail, blocking a PR 5 to ansible-role-cli 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,5 @@
 - name: update and upgrade homebrew
   homebrew: update_homebrew=yes upgrade_all=yes
 
-- name: install homebrew cask
-  homebrew_tap: tap=caskroom/cask state=present
-
 - name: install homebrew services
   homebrew_tap: tap=homebrew/services state=present


### PR DESCRIPTION
Deprecation of taps and inclusion of cask into the base homebrew have caused failure of some of these superlumic roles. @wolfeidau PRed a fix to ansible-role-cli[1], but that fails because this role is trying to install cask in a deprecated way [2]. The documentation for fix #3 suggests using another tap, but that may not be necessary.

[1] https://github.com/superlumic/ansible-role-cli/pull/5
[2] https://github.com/Homebrew/homebrew-core/issues/131